### PR TITLE
Move comment out of MAX_ITERATIONS variable in example env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,8 @@ EMBEDDING=openai:text-embedding-3-small
 STRATEGIC_LLM=openai:gpt-4o-mini # To increase speed, use gpt-4o-mini
 
 # Maximum number of research iterations
-MAX_ITERATIONS=2 # To increase speed, use 2
+# (To increase speed, use 2)
+MAX_ITERATIONS=2
 
 # Optional example: Anthropic API key if using Claude
 # ANTHROPIC_API_KEY=your_anthropic_api_key_here


### PR DESCRIPTION
E.g. when using Docker Swarm mode, the comment would end up as part of the variable value otherwise.