### PR TITLE
Fix busy-spin CPU pin after stdio transport disconnects

### DIFF
--- a/server.py
+++ b/server.py
@@ -306,10 +306,9 @@ def run_server():
         else:
             raise ValueError(f"Unsupported transport: {transport}")
             
-        # Note: If we reach here, the server has stopped
-        logger.info("MCP Server is running...")
-        while True:
-            pass  # Keep the process alive
+        # mcp.run() blocks until the transport shuts down, so reaching here
+        # means the server has already stopped (e.g. stdio client disconnected).
+        logger.info("MCP Server has stopped.")
     except Exception as e:
         logger.error(f"Error running MCP server: {str(e)}")
         print(f"❌ MCP Server error: {str(e)}")


### PR DESCRIPTION
## Summary
- `run_server()` had a trailing `while True: pass` meant to "keep the process alive" after `mcp.run()` returns.
- `mcp.run()` already blocks until the transport shuts down, so reaching that code means the server has already stopped (e.g. the stdio client disconnected).
- The empty spin loop has no sleep/yield, so it pins one CPU core at 100% indefinitely until the process is manually killed.
- Easy to reproduce: any MCP client that spawns this server over stdio and later disconnects leaves an orphaned process spinning at 100% CPU forever. I hit this myself — the process had been running at 100% CPU for over two days before I noticed.

## Fix
Remove the busy-spin loop and let `run_server()` exit cleanly with a log line once `mcp.run()` returns, since there's nothing left to do at that point.

## Test plan
- [x] Read through `run_server()` control flow to confirm `mcp.run()` is blocking and the trailing code only runs after shutdown
- [x] Ran the server locally over stdio and confirmed it now exits cleanly on disconnect instead of spinning