### PR TITLE
Progress notifications for long calls, report synthesis by default, fix content_length always 0

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ python server.py
 
 | Variable | Description | Default | Example |
 |----------|-------------|---------|---------|
-| `MCP_TRANSPORT` | Force specific transport | `stdio` | `sse`, `streamable-http` |
+| `MCP_TRANSPORT` | Force specific transport | `stdio` (`sse` if Docker is detected and this is unset) | `sse`, `streamable-http` |
 | `DOCKER_CONTAINER` | Force Docker mode | Auto-detected | `true` |
 
 ### Configuration Examples

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,12 +4,14 @@
 # monkeypatches (with real ordering dependencies between them) became more
 # complex than owning the fixes as native code. See MrSampson/gpt-researcher's
 # spark-production branch and services/research/README.md's "Forked
-# gpt-researcher" section for the full rationale and the individual
-# upstream PRs each fix was also submitted as (#1943, #1944, #1951, #1952).
+# gpt-researcher" section for the full rationale. #1943, #1944, #1951 and
+# #1952 landed upstream (in a re-authored form) and were reconciled into
+# spark-production on 2026-08-24 when it was synced with upstream/main;
+# #1960, #1961 and #1967 are still open upstream.
 # Pin to a specific commit, same as the mcp SDK override below -- rebase
 # and bump periodically, dropping whichever fixes upstream has since
 # merged and released.
-gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@5ece4bed060b37171aef21c3d58be4a3eaf45a08
+gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@41897e5c5a7160f564600e04bb889c7c12c343f4
 python-dotenv
 
 # MCP dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,15 @@
 # GPT Researcher dependencies
 # Installed from our fork, not PyPI: gpt-researcher accumulated enough
-# separately-tracked bug fixes (issues #17, #20, #24 at spark-ba88) that
-# maintaining several interacting monkeypatches (with real ordering
-# dependencies between them) became more complex than owning the fixes as
-# native code. See MrSampson/gpt-researcher's spark-production branch and
-# services/research/README.md's "Forked gpt-researcher" section for the
-# full rationale and the individual upstream PRs each fix was also
-# submitted as (#1943, #1944, #1951, #1952). Pin to a specific commit,
-# same as the mcp SDK override below -- rebase and bump periodically,
-# dropping whichever fixes upstream has since merged and released.
-gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@c192b6cc4f33c6f680834783fb49cb8d67c2c94d
+# separately-tracked bug fixes that maintaining several interacting
+# monkeypatches (with real ordering dependencies between them) became more
+# complex than owning the fixes as native code. See MrSampson/gpt-researcher's
+# spark-production branch and services/research/README.md's "Forked
+# gpt-researcher" section for the full rationale and the individual
+# upstream PRs each fix was also submitted as (#1943, #1944, #1951, #1952).
+# Pin to a specific commit, same as the mcp SDK override below -- rebase
+# and bump periodically, dropping whichever fixes upstream has since
+# merged and released.
+gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@7190cf78a2b1aaa0864ec09d5b1fb59b217dac7c
 python-dotenv
 
 # MCP dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 # Pin to a specific commit, same as the mcp SDK override below -- rebase
 # and bump periodically, dropping whichever fixes upstream has since
 # merged and released.
-gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@7190cf78a2b1aaa0864ec09d5b1fb59b217dac7c
+gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@8ec03e78b48964318a672413a341ea5e390a592e
 python-dotenv
 
 # MCP dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 # Pin to a specific commit, same as the mcp SDK override below -- rebase
 # and bump periodically, dropping whichever fixes upstream has since
 # merged and released.
-gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@8ec03e78b48964318a672413a341ea5e390a592e
+gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@5ece4bed060b37171aef21c3d58be4a3eaf45a08
 python-dotenv
 
 # MCP dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,11 @@
 # GPT Researcher dependencies
-gpt-researcher>=0.14.0
+# Upper bound excludes 0.16.0: gpt_researcher/actions/query_processing.py's
+# import ordering bug makes the entire package fail to import on that
+# release (NameError: name 'Any' is not defined at module load time).
+# Confirmed 0.14.8/0.15.0/0.15.1 all import fine; fix submitted upstream as
+# https://github.com/assafelovic/gpt-researcher/pull/1943 -- once merged and
+# released, this upper bound can be dropped.
+gpt-researcher>=0.14.0,<0.16.0
 python-dotenv
 
 # MCP dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
 # GPT Researcher dependencies
-# Upper bound excludes 0.16.0: gpt_researcher/actions/query_processing.py's
-# import ordering bug makes the entire package fail to import on that
-# release (NameError: name 'Any' is not defined at module load time).
-# Confirmed 0.14.8/0.15.0/0.15.1 all import fine; fix submitted upstream as
-# https://github.com/assafelovic/gpt-researcher/pull/1943 -- once merged and
-# released, this upper bound can be dropped.
-gpt-researcher>=0.14.0,<0.16.0
+# Installed from our fork, not PyPI: gpt-researcher accumulated enough
+# separately-tracked bug fixes (issues #17, #20, #24 at spark-ba88) that
+# maintaining several interacting monkeypatches (with real ordering
+# dependencies between them) became more complex than owning the fixes as
+# native code. See MrSampson/gpt-researcher's spark-production branch and
+# services/research/README.md's "Forked gpt-researcher" section for the
+# full rationale and the individual upstream PRs each fix was also
+# submitted as (#1943, #1944, #1951, #1952). Pin to a specific commit,
+# same as the mcp SDK override below -- rebase and bump periodically,
+# dropping whichever fixes upstream has since merged and released.
+gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@213f766bf6f03160585f020e1ed4ef9778f47a2f
 python-dotenv
 
 # MCP dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@
 # submitted as (#1943, #1944, #1951, #1952). Pin to a specific commit,
 # same as the mcp SDK override below -- rebase and bump periodically,
 # dropping whichever fixes upstream has since merged and released.
-gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@213f766bf6f03160585f020e1ed4ef9778f47a2f
+gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@c192b6cc4f33c6f680834783fb49cb8d67c2c94d
 python-dotenv
 
 # MCP dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,13 @@ gpt-researcher @ git+https://github.com/MrSampson/gpt-researcher.git@41897e5c5a7
 python-dotenv
 
 # MCP dependencies
-fastmcp>=2.8.0
+# Pinned exact, like the gpt-researcher and mcp SDK overrides above: this
+# was previously an unbounded floor (`>=2.8.0`), and fastmcp's 4.0.0
+# release (mcp<3.0.0,>=2.0.0) broke every install pinned to an mcp 1.x
+# SDK the moment it went stable, since fastmcp 3.x only ever required
+# mcp<2.0,>=1.24.0. 3.4.7 is the last 3.x release and the version this
+# fork is actually verified against.
+fastmcp==3.4.7
 fastapi>=0.103.1
 uvicorn>=0.23.2
 pydantic>=2.3.0

--- a/server.py
+++ b/server.py
@@ -348,14 +348,14 @@ def run_server():
         logger.error("OPENAI_API_KEY not found. Please set it in your .env file.")
         return
 
-    # Determine transport based on environment
-    transport = os.getenv("MCP_TRANSPORT", "stdio").lower()
-    
-    # Auto-detect Docker environment
-    if os.path.exists("/.dockerenv") or os.getenv("DOCKER_CONTAINER"):
-        transport = "sse"
-        logger.info("Docker environment detected, using SSE transport")
-    
+    # An explicit MCP_TRANSPORT always wins; Docker auto-detection only
+    # supplies a default when it's unset (or blank).
+    transport = (os.getenv("MCP_TRANSPORT") or "").strip().lower()
+    if not transport:
+        in_docker = os.path.exists("/.dockerenv") or bool(os.getenv("DOCKER_CONTAINER"))
+        transport = "sse" if in_docker else "stdio"
+        logger.info(f"MCP_TRANSPORT unset, defaulting to {transport} transport")
+
     # Add startup message
     logger.info(f"Starting GPT Researcher MCP Server with {transport} transport...")
     print(f"🚀 GPT Researcher MCP Server starting with {transport} transport...")

--- a/server.py
+++ b/server.py
@@ -12,7 +12,7 @@ import logging
 from typing import Dict, Any, Optional, List
 from dotenv import load_dotenv
 from fastapi.responses import JSONResponse
-from fastmcp import FastMCP
+from fastmcp import Context, FastMCP
 from gpt_researcher import GPTResearcher
 
 # Load environment variables
@@ -20,13 +20,14 @@ load_dotenv()
 
 from utils import (
     research_store,
-    create_success_response, 
+    create_success_response,
     handle_exception,
-    get_researcher_by_id, 
+    get_researcher_by_id,
     format_sources_for_response,
-    format_context_with_sources, 
+    format_context_with_sources,
     store_research_results,
-    create_research_prompt
+    create_research_prompt,
+    ProgressLogHandler,
 )
 
 logging.basicConfig(
@@ -91,73 +92,90 @@ async def research_resource(topic: str) -> str:
 
 
 @mcp.tool()
-async def deep_research(query: str) -> Dict[str, Any]:
+async def deep_research(
+    query: str, ctx: Context, synthesize_report: bool = True
+) -> Dict[str, Any]:
     """
-    Conduct a web deep research on a given query using GPT Researcher. 
+    Conduct a web deep research on a given query using GPT Researcher.
     Use this tool when you need time-sensitive, real-time information like stock prices, news, people, specific knowledge, etc.
-    
+
     Args:
         query: The research query or topic
-        
+        synthesize_report: If True (default), also synthesize and return a
+            written report alongside the raw context. Set False to skip
+            synthesis and get gather-only results faster/cheaper -- the
+            write_report tool can still be called later with the returned
+            research_id.
+
     Returns:
-        Dict containing research status, ID, and the actual research context and sources
-        that can be used directly by LLMs for context enrichment
+        Dict containing research status, ID, the actual research context and
+        sources (for direct LLM context enrichment), and -- unless
+        synthesize_report is False -- a synthesized "report".
     """
     logger.info(f"Conducting research on query: {query}...")
-    
+
     # Generate a unique ID for this research session
     research_id = str(uuid.uuid4())
-    
-    # Initialize GPT Researcher
-    researcher = GPTResearcher(query)
-    
+
+    # Initialize GPT Researcher. log_handler forwards conduct_research()'s
+    # internal step events to MCP progress notifications on this call's
+    # context, so long-running research resets the client's idle timeout
+    # instead of running silently until it finishes or gets aborted.
+    researcher = GPTResearcher(query, log_handler=ProgressLogHandler(ctx))
+
     # Start research
     try:
         await researcher.conduct_research()
         mcp.researchers[research_id] = researcher
         logger.info(f"Research completed for ID: {research_id}")
-        
+
         # Get the research context and sources
         context = researcher.get_research_context()
         sources = researcher.get_research_sources()
         source_urls = researcher.get_source_urls()
-        
+
         # Store in the research store for the resource API
         store_research_results(query, context, sources, source_urls)
-        
-        return create_success_response({
+
+        response_data = {
             "research_id": research_id,
             "query": query,
             "source_count": len(sources),
             "context": context,
             "sources": format_sources_for_response(sources),
             "source_urls": source_urls
-        })
+        }
+
+        if synthesize_report:
+            logger.info(f"Synthesizing report for research ID: {research_id}")
+            response_data["report"] = await researcher.write_report()
+
+        return create_success_response(response_data)
     except Exception as e:
         return handle_exception(e, "Research")
 
 
 @mcp.tool()
-async def quick_search(query: str) -> Dict[str, Any]:
+async def quick_search(query: str, ctx: Context) -> Dict[str, Any]:
     """
     Perform a quick web search on a given query and return search results with snippets.
     This optimizes for speed over quality and is useful when an LLM doesn't need in-depth
     information on a topic.
-    
+
     Args:
         query: The search query
-        
+
     Returns:
         Dict containing search results and snippets
     """
     logger.info(f"Performing quick search on query: {query}...")
-    
+
     # Generate a unique ID for this search session
     search_id = str(uuid.uuid4())
-    
+
     # Initialize GPT Researcher
-    researcher = GPTResearcher(query)
-    
+    researcher = GPTResearcher(query, log_handler=ProgressLogHandler(ctx))
+
     try:
         # Perform quick search
         search_results = await researcher.quick_search(query=query)

--- a/server.py
+++ b/server.py
@@ -91,6 +91,58 @@ async def research_resource(topic: str) -> str:
         return f"Error conducting research on '{topic}': {str(e)}"
 
 
+def _make_researcher(query: str, ctx: Context) -> GPTResearcher:
+    """Build a GPTResearcher with MCP progress reporting wired for both of
+    gpt_researcher's independent signal paths -- see ProgressLogHandler's
+    docstring for why both log_handler= and websocket= are required. Both
+    tools pass the same handler instance so the two paths share one
+    monotonic progress counter instead of each emitting its own,
+    interleaved and out of order.
+
+    Note: only deep_research's conduct_research() actually exercises the
+    websocket path -- quick_search's retriever path
+    (gpt_researcher.actions.query_processing.get_search_results) never
+    calls stream_output, so websocket= is inert during quick_search()
+    itself. It's still wired here, for uniformity and so it works for free
+    if that path ever grows streaming, and because the researcher this
+    returns can later be reused by the standalone write_report tool (see
+    _release_progress_websocket).
+    """
+    handler = ProgressLogHandler(ctx)
+    return GPTResearcher(query, log_handler=handler, websocket=handler)
+
+
+def _release_progress_websocket(researcher: GPTResearcher) -> None:
+    """Clear `websocket` once conduct_research()/quick_search() is done,
+    before the researcher is stored in mcp.researchers for reuse by a
+    later call.
+
+    A non-None `websocket` makes gpt_researcher's report-writing LLM call
+    disable its normal 10-attempt retry budget (stream=True and websocket
+    is not None -> 1 attempt instead of 10; see utils/llm.py) and
+    re-stream the entire generated report back through it, paragraph by
+    paragraph, as if it were progress -- neither wanted for report
+    generation, only for search-loop progress.
+
+    Must run before storage, not just before an inline write_report()
+    call: deep_research(synthesize_report=False) and quick_search() both
+    store their researcher in mcp.researchers, and the standalone
+    write_report tool reuses it later via research_id/search_id -- that
+    reuse needs the same clearing, or it hits the same regression.
+
+    Depends on a companion fix in the gpt-researcher fork:
+    ReportGenerator.write_report() must read researcher.websocket live at
+    call time, not the value gpt_researcher/skills/writer.py currently
+    freezes into research_params at GPTResearcher construction. Until that
+    fix is installed, this clear does silence a few verbose progress
+    messages gpt_researcher's write_report() reads live elsewhere (e.g.
+    the "writing_report" ping), but the retry-budget and re-streaming
+    problems above are not yet actually fixed -- see
+    test_installed_gpt_researcher_reads_websocket_live_at_report_time.
+    """
+    researcher.websocket = None
+
+
 @mcp.tool()
 async def deep_research(
     query: str, ctx: Context, synthesize_report: bool = True
@@ -117,15 +169,12 @@ async def deep_research(
     # Generate a unique ID for this research session
     research_id = str(uuid.uuid4())
 
-    # Initialize GPT Researcher. log_handler forwards conduct_research()'s
-    # internal step events to MCP progress notifications on this call's
-    # context, so long-running research resets the client's idle timeout
-    # instead of running silently until it finishes or gets aborted.
-    researcher = GPTResearcher(query, log_handler=ProgressLogHandler(ctx))
+    researcher = _make_researcher(query, ctx)
 
     # Start research
     try:
         await researcher.conduct_research()
+        _release_progress_websocket(researcher)
         mcp.researchers[research_id] = researcher
         logger.info(f"Research completed for ID: {research_id}")
 
@@ -173,12 +222,12 @@ async def quick_search(query: str, ctx: Context) -> Dict[str, Any]:
     # Generate a unique ID for this search session
     search_id = str(uuid.uuid4())
 
-    # Initialize GPT Researcher
-    researcher = GPTResearcher(query, log_handler=ProgressLogHandler(ctx))
+    researcher = _make_researcher(query, ctx)
 
     try:
         # Perform quick search
         search_results = await researcher.quick_search(query=query)
+        _release_progress_websocket(researcher)
         mcp.researchers[search_id] = researcher
         logger.info(f"Quick search completed for ID: {search_id}")
         

--- a/tests/test_deep_research_fixes.py
+++ b/tests/test_deep_research_fixes.py
@@ -1,10 +1,14 @@
 #!/usr/bin/env python3
 """
-Regression test for three deep_research/quick_search fixes:
+Regression test for deep_research/quick_search fixes:
 
 1. Progress notifications: long-running calls now report MCP progress via
    ProgressLogHandler, so a client doesn't sit with no signal until the call
-   finishes or its idle timeout aborts the connection.
+   finishes or its idle timeout aborts the connection. This covers both of
+   gpt_researcher's independent progress paths -- log_handler (coarse
+   macro-checkpoints) and websocket (the fine-grained per-sub-query/
+   per-source progress emitted during the actual search/scrape loop) --
+   sharing one handler instance so both paths keep one monotonic counter.
 2. Report synthesis: deep_research now also calls write_report() and
    returns it as "report" by default (synthesize_report=True), instead of
    only ever returning raw context that the caller had to know to pass to
@@ -13,10 +17,27 @@ Regression test for three deep_research/quick_search fixes:
    key GPTResearcher.get_research_sources() actually populates, instead of
    a "content" key that was never present -- content_length was 0 for every
    source regardless of how much text was actually scraped.
+4. The progress websocket is released (set to None) right after
+   conduct_research()/quick_search() completes and before the researcher is
+   stored in mcp.researchers, not just before an inline write_report() call.
+   gpt_researcher's report-generation LLM call disables its normal
+   10-attempt retry budget whenever a websocket is set and re-streams the
+   whole report back through it as fake progress -- neither is wanted for
+   report generation, only for search-loop progress. Releasing it only
+   inside the synthesize_report=True branch left it armed on any researcher
+   later reused by the standalone write_report tool via
+   synthesize_report=False's documented research_id/search_id flow --
+   exactly the workflow this fix exists to protect, hit through a second,
+   easy-to-miss door. See server.py's _release_progress_websocket.
+5. ProgressLogHandler's failure-swallowing log call uses
+   logger.opt(exception=True), not the stdlib-style exc_info=True kwarg --
+   loguru silently discards exc_info= (it's absorbed as an unused
+   str.format() argument), which would otherwise turn every swallowed
+   failure into a traceback-free, undiagnosable log line.
 
 Does not require the real gpt_researcher package: patches server.GPTResearcher
 with a lightweight fake so this runs fast and without network/LLM access.
-Run directly:
+Collectible by pytest; also runnable directly:
 
     python3 tests/test_deep_research_fixes.py
 """
@@ -25,6 +46,8 @@ import asyncio
 import os
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
 from unittest.mock import patch
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
@@ -32,9 +55,22 @@ os.environ.setdefault("OPENAI_API_KEY", "unused-dummy-value-for-tests")
 
 
 class _FakeGPTResearcher:
-    def __init__(self, query, log_handler=None, **kwargs):
+    # Every constructed instance, in order, so a test can inspect what
+    # server.py actually passed in and to which object -- independent of
+    # the fake's own simulated event counts. Reset at the start of each
+    # test that constructs one.
+    instances: list = []
+
+    def __init__(self, query, log_handler=None, websocket=None, **kwargs):
         self.query = query
         self.log_handler = log_handler
+        self.websocket = websocket
+        # self.websocket gets mutated (cleared) by server.py after
+        # conduct_research(); keep the original construction-time value so
+        # a test can still check what was actually passed in.
+        self.websocket_at_construction = websocket
+        self.websocket_at_write_report = "not-called"
+        _FakeGPTResearcher.instances.append(self)
         self._sources = [
             {"title": "Example", "url": "http://example.com", "raw_content": "x" * 250},
             {"title": "NoContent", "url": "http://example.com/2"},
@@ -44,6 +80,15 @@ class _FakeGPTResearcher:
         if self.log_handler:
             await self.log_handler.on_research_step("start", {})
             await self.log_handler.on_tool_start("web_search")
+        # Mirrors gpt_researcher's real stream_output() calls
+        # (gpt_researcher/actions/utils.py), made throughout the actual
+        # sub-query search/scrape loop -- the real bottleneck. That's a
+        # separate mechanism from log_handler, gated on `websocket` alone --
+        # this path was never wired to MCP progress before this fix.
+        if self.websocket:
+            await self.websocket.send_json({"type": "logs", "output": "running sub-query 1"})
+            await self.websocket.send_json({"type": "logs", "output": "running sub-query 2"})
+        if self.log_handler:
             await self.log_handler.on_research_step("research_completed", {})
 
     async def quick_search(self, query):
@@ -52,6 +97,11 @@ class _FakeGPTResearcher:
         return [{"title": "quick", "url": "http://example.com", "snippet": "..."}]
 
     async def write_report(self, custom_prompt=None):
+        # server.py must have released the researcher's websocket before
+        # this runs -- either inline (deep_research(synthesize_report=True))
+        # or earlier, before the researcher was stored for reuse by the
+        # standalone write_report tool. See _release_progress_websocket.
+        self.websocket_at_write_report = self.websocket
         return f"# Report for {self.query}\n\nSynthesized findings."
 
     def get_research_context(self):
@@ -71,7 +121,11 @@ async def _run() -> None:
     import server
     from fastmcp import Client
 
+    _FakeGPTResearcher.instances.clear()
+
     with patch("server.GPTResearcher", _FakeGPTResearcher):
+        instances = _FakeGPTResearcher.instances
+
         progress_events = []
 
         async def on_progress(progress, total, message):
@@ -84,7 +138,28 @@ async def _run() -> None:
             assert data["status"] == "success", data
             assert "report" in data, "synthesize_report defaults True, report must be present"
             assert data["report"].startswith("# Report for test query"), data["report"]
-            assert len(progress_events) >= 3, f"expected >=3 progress events, got {progress_events}"
+            # 2 log_handler checkpoints + 2 websocket-path sub-query events;
+            # the websocket-path count catches the regression this fake
+            # simulates: without websocket= wired, log_handler alone only
+            # covers the coarse macro-checkpoints, not the actual
+            # search/scrape loop where these events would really fire.
+            assert len(progress_events) >= 4, f"expected >=4 progress events (log_handler + websocket path), got {progress_events}"
+
+            first_researcher = instances[-1]
+
+            # The construction itself: both paths must be wired, and to the
+            # *same* handler instance -- two separate instances would each
+            # keep their own step counter and emit colliding, non-monotonic
+            # progress values.
+            assert first_researcher.websocket_at_construction is not None, "websocket= must be wired for search-loop progress"
+            assert first_researcher.websocket_at_construction is first_researcher.log_handler, "both progress paths must share one handler instance"
+
+            # Fix 4: websocket must be cleared before the inline write_report() runs.
+            assert first_researcher.websocket_at_write_report is None, (
+                "write_report() must be called with the researcher's websocket "
+                "cleared, or the report LLM call loses its retry budget and "
+                "the whole report gets re-streamed back as progress"
+            )
 
             # Fix 3: content_length reflects raw_content, missing key doesn't crash.
             assert data["sources"][0]["content_length"] == 250, data["sources"]
@@ -96,15 +171,163 @@ async def _run() -> None:
                 "deep_research", {"query": "no report please", "synthesize_report": False}
             )
             assert "report" not in result2.data, "synthesize_report=False must omit report"
+            research_id = result2.data["research_id"]
 
-            # quick_search also reports progress.
+            # Fix 4's second door: a later, standalone write_report call
+            # against a researcher stored via synthesize_report=False must
+            # ALSO see a cleared websocket, not just the inline call above.
+            # The websocket must have been released before storage, not
+            # only inside the synthesize_report=True branch.
+            result4 = await client.call_tool("write_report", {"research_id": research_id})
+            assert result4.data["status"] == "success", result4.data
+            deferred_researcher = instances[-1]
+            assert deferred_researcher.websocket_at_write_report is None, (
+                "a researcher stored via synthesize_report=False and later handed to "
+                "the standalone write_report tool must also see websocket=None -- "
+                "the release must happen before storage, not only before an inline "
+                "write_report() call"
+            )
+
+            # quick_search also reports progress, and its stored researcher
+            # must be released the same way (it can also be reused via
+            # write_report, through the same mcp.researchers dict).
             progress_events.clear()
             result3 = await client.call_tool("quick_search", {"query": "fast query"})
             assert result3.data["status"] == "success", result3.data
             assert len(progress_events) >= 1, "quick_search must report progress too"
+            search_id = result3.data["search_id"]
 
-    print("OK: deep_research/quick_search progress, report synthesis, and content_length fixes verified")
+            result5 = await client.call_tool("write_report", {"research_id": search_id})
+            assert result5.data["status"] == "success", result5.data
+            searched_researcher = instances[-1]
+            assert searched_researcher.websocket_at_write_report is None
+
+
+def test_deep_research_and_quick_search_progress_and_report_fixes() -> None:
+    asyncio.run(_run())
+
+
+async def _run_send_json_fallbacks() -> None:
+    from utils import ProgressLogHandler
+
+    events = []
+
+    class _FakeCtx:
+        async def report_progress(self, progress: int, message: str) -> None:
+            events.append((progress, message))
+
+    handler = ProgressLogHandler(_FakeCtx())
+
+    # Each of send_json's fallback branches, in priority order.
+    await handler.send_json({"output": "from output", "content": "ignored", "type": "ignored"})
+    await handler.send_json({"content": "from content", "type": "ignored"})
+    await handler.send_json({"type": "from type"})
+    await handler.send_json({})
+
+    assert [message for _, message in events] == [
+        "from output",
+        "from content",
+        "from type",
+        "progress",
+    ], events
+
+
+def test_progress_log_handler_send_json_covers_all_fallback_branches() -> None:
+    asyncio.run(_run_send_json_fallbacks())
+
+
+async def _run_report_progress_failure_does_not_abort() -> None:
+    from utils import ProgressLogHandler
+
+    class _FailingCtx:
+        async def report_progress(self, progress: int, message: str) -> None:
+            raise RuntimeError("client disconnected")
+
+    handler = ProgressLogHandler(_FailingCtx())
+
+    # gpt_researcher's websocket-shaped stream_output() awaits send_json()
+    # unguarded (unlike the defensive log_handler path in agent.py's
+    # _log_event), so a broken transport here must not propagate and abort
+    # whatever research is still in progress.
+    await handler.send_json({"output": "progress update"})
+    await handler.on_research_step("some_step", {})
+
+
+def test_progress_log_handler_swallows_report_progress_failures() -> None:
+    asyncio.run(_run_report_progress_failure_does_not_abort())
+
+
+class _StubResearcherForReportGenerator:
+    """Minimal stand-in for GPTResearcher, covering every attribute
+    ReportGenerator.write_report() touches on the non-subtopic path."""
+
+    def __init__(self, websocket):
+        self.query = "q"
+        self.cfg = SimpleNamespace(agent_role="role prompt")
+        self.role = "role"
+        self.report_type = "research_report"
+        self.report_source = "web"
+        self.tone = "objective"
+        self.websocket = websocket
+        self.headers = {}
+        self.verbose = False
+        self.context = "some research context"
+        self.kwargs = {}
+
+    def add_costs(self, *args, **kwargs) -> None:
+        pass
+
+    def get_research_images(self):
+        return []
+
+
+async def _run_installed_gpt_researcher_live_websocket_check() -> None:
+    """server.py's _release_progress_websocket() relies on
+    ReportGenerator.write_report() re-reading researcher.websocket live
+    rather than a value frozen into research_params at __init__ time (a
+    separate fix in the gpt-researcher fork). Verify that behaviorally
+    against whatever gpt_researcher is actually installed/pinned right
+    now: construct a real ReportGenerator, mutate websocket after
+    construction the way server.py does, and check what actually reaches
+    generate_report(). This is deliberately behavioral rather than
+    grepping write_report()'s source -- a source-text match breaks on any
+    behavior-preserving refactor (renamed variable, reformatted line, an
+    equally-correct alternative fix shaped differently); asserting on the
+    real call's kwargs does not.
+    """
+    from gpt_researcher.skills import writer
+
+    captured: Dict[str, Any] = {}
+
+    async def _fake_generate_report(**kwargs: Any) -> str:
+        captured.update(kwargs)
+        return "report"
+
+    researcher = _StubResearcherForReportGenerator(websocket=object())
+    generator = writer.ReportGenerator(researcher)
+    # Mutate after construction, exactly as _release_progress_websocket does.
+    researcher.websocket = None
+
+    with patch.object(writer, "generate_report", _fake_generate_report):
+        await generator.write_report()
+
+    assert captured.get("websocket") is None, (
+        "installed gpt_researcher's ReportGenerator.write_report() does not "
+        "re-read researcher.websocket live -- server.py's "
+        "_release_progress_websocket() is a no-op against this pin. "
+        "Re-pin requirements.txt to a gpt-researcher commit containing the "
+        "live-read fix (MrSampson/gpt-researcher, "
+        "fix/report-generator-live-websocket) before relying on this."
+    )
+
+
+def test_installed_gpt_researcher_reads_websocket_live_at_report_time() -> None:
+    asyncio.run(_run_installed_gpt_researcher_live_websocket_check())
 
 
 if __name__ == "__main__":
-    asyncio.run(_run())
+    test_deep_research_and_quick_search_progress_and_report_fixes()
+    test_progress_log_handler_send_json_covers_all_fallback_branches()
+    test_progress_log_handler_swallows_report_progress_failures()
+    test_installed_gpt_researcher_reads_websocket_live_at_report_time()
+    print("OK: deep_research/quick_search progress, report synthesis, retry-budget, and content_length fixes verified")

--- a/tests/test_deep_research_fixes.py
+++ b/tests/test_deep_research_fixes.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""
+Regression test for three deep_research/quick_search fixes:
+
+1. Progress notifications: long-running calls now report MCP progress via
+   ProgressLogHandler, so a client doesn't sit with no signal until the call
+   finishes or its idle timeout aborts the connection.
+2. Report synthesis: deep_research now also calls write_report() and
+   returns it as "report" by default (synthesize_report=True), instead of
+   only ever returning raw context that the caller had to know to pass to
+   the separate write_report tool.
+3. content_length: format_sources_for_response() now reads the "raw_content"
+   key GPTResearcher.get_research_sources() actually populates, instead of
+   a "content" key that was never present -- content_length was 0 for every
+   source regardless of how much text was actually scraped.
+
+Does not require the real gpt_researcher package: patches server.GPTResearcher
+with a lightweight fake so this runs fast and without network/LLM access.
+Run directly:
+
+    python3 tests/test_deep_research_fixes.py
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("OPENAI_API_KEY", "unused-dummy-value-for-tests")
+
+
+class _FakeGPTResearcher:
+    def __init__(self, query, log_handler=None, **kwargs):
+        self.query = query
+        self.log_handler = log_handler
+        self._sources = [
+            {"title": "Example", "url": "http://example.com", "raw_content": "x" * 250},
+            {"title": "NoContent", "url": "http://example.com/2"},
+        ]
+
+    async def conduct_research(self):
+        if self.log_handler:
+            await self.log_handler.on_research_step("start", {})
+            await self.log_handler.on_tool_start("web_search")
+            await self.log_handler.on_research_step("research_completed", {})
+
+    async def quick_search(self, query):
+        if self.log_handler:
+            await self.log_handler.on_research_step("quick_search_start", {})
+        return [{"title": "quick", "url": "http://example.com", "snippet": "..."}]
+
+    async def write_report(self, custom_prompt=None):
+        return f"# Report for {self.query}\n\nSynthesized findings."
+
+    def get_research_context(self):
+        return f"context for {self.query}"
+
+    def get_research_sources(self):
+        return self._sources
+
+    def get_source_urls(self):
+        return [s["url"] for s in self._sources]
+
+    def get_costs(self):
+        return 0.0
+
+
+async def _run() -> None:
+    import server
+    from fastmcp import Client
+
+    with patch("server.GPTResearcher", _FakeGPTResearcher):
+        progress_events = []
+
+        async def on_progress(progress, total, message):
+            progress_events.append((progress, message))
+
+        async with Client(server.mcp, progress_handler=on_progress) as client:
+            # Fix 1 + 2: progress reported, report synthesized by default.
+            result = await client.call_tool("deep_research", {"query": "test query"})
+            data = result.data
+            assert data["status"] == "success", data
+            assert "report" in data, "synthesize_report defaults True, report must be present"
+            assert data["report"].startswith("# Report for test query"), data["report"]
+            assert len(progress_events) >= 3, f"expected >=3 progress events, got {progress_events}"
+
+            # Fix 3: content_length reflects raw_content, missing key doesn't crash.
+            assert data["sources"][0]["content_length"] == 250, data["sources"]
+            assert data["sources"][1]["content_length"] == 0, data["sources"]
+
+            # synthesize_report=False must omit the report.
+            progress_events.clear()
+            result2 = await client.call_tool(
+                "deep_research", {"query": "no report please", "synthesize_report": False}
+            )
+            assert "report" not in result2.data, "synthesize_report=False must omit report"
+
+            # quick_search also reports progress.
+            progress_events.clear()
+            result3 = await client.call_tool("quick_search", {"query": "fast query"})
+            assert result3.data["status"] == "success", result3.data
+            assert len(progress_events) >= 1, "quick_search must report progress too"
+
+    print("OK: deep_research/quick_search progress, report synthesis, and content_length fixes verified")
+
+
+if __name__ == "__main__":
+    asyncio.run(_run())

--- a/utils.py
+++ b/utils.py
@@ -111,6 +111,38 @@ def store_research_results(topic: str, context: str, sources: List[Dict[str, Any
     }
 
 
+class ProgressLogHandler:
+    """Forwards GPTResearcher's internal step events (agent.py's
+    _log_event("research"/"tool"/"action", ...) checkpoints, fired
+    throughout conduct_research()) to MCP progress notifications on the
+    calling tool's request context.
+
+    Long research/search calls can legitimately exceed a client's idle
+    timeout; without any signal of ongoing work, the client has no way to
+    distinguish "still working" from "hung", and may abort. Each progress
+    notification resets the client's idle timer for clients that implement
+    the standard MCP behavior of resetting request timeouts on progress
+    notifications tied to the request's progressToken.
+    """
+
+    def __init__(self, ctx) -> None:
+        self._ctx = ctx
+        self._step = 0
+
+    async def on_research_step(self, step: str, details: Dict[str, Any]) -> None:
+        await self._report(step)
+
+    async def on_tool_start(self, tool_name: str, **kwargs: Any) -> None:
+        await self._report(f"tool:{tool_name}")
+
+    async def on_agent_action(self, action: str, **kwargs: Any) -> None:
+        await self._report(f"action:{action}")
+
+    async def _report(self, message: str) -> None:
+        self._step += 1
+        await self._ctx.report_progress(progress=self._step, message=message)
+
+
 def create_research_prompt(topic: str, goal: str, report_format: str = "research_report") -> str:
     """
     Create a research query prompt for GPT Researcher.

--- a/utils.py
+++ b/utils.py
@@ -112,10 +112,8 @@ def store_research_results(topic: str, context: str, sources: List[Dict[str, Any
 
 
 class ProgressLogHandler:
-    """Forwards GPTResearcher's internal step events (agent.py's
-    _log_event("research"/"tool"/"action", ...) checkpoints, fired
-    throughout conduct_research()) to MCP progress notifications on the
-    calling tool's request context.
+    """Forwards GPTResearcher's progress signals to MCP progress
+    notifications on the calling tool's request context.
 
     Long research/search calls can legitimately exceed a client's idle
     timeout; without any signal of ongoing work, the client has no way to
@@ -123,6 +121,28 @@ class ProgressLogHandler:
     notification resets the client's idle timer for clients that implement
     the standard MCP behavior of resetting request timeouts on progress
     notifications tied to the request's progressToken.
+
+    gpt_researcher has two independent, non-overlapping progress signal
+    paths, and both must be wired for real coverage:
+
+    - `log_handler` (agent.py's `_log_event`, handled below by
+      `on_research_step`/`on_tool_start`/`on_agent_action`) fires only a
+      handful of coarse macro-checkpoints: research start, agent selection,
+      "conducting_research", "research_completed", etc.
+    - the actual fine-grained, per-sub-query and per-source progress --
+      emitted throughout the real bottleneck: query planning, searching,
+      scraping, retrying blocked fetches -- goes through a *separate*
+      websocket-shaped call, `stream_output()`
+      (gpt_researcher/actions/utils.py), gated on `researcher.websocket`
+      being truthy and duck-typed to only need an async `send_json(data)`
+      method.
+
+    Passing this handler as `log_handler=` alone leaves that second path
+    unwired, so everything between the "conducting_research" and
+    "research_completed" checkpoints -- which is where all the actual
+    search/scrape work and retry time lives -- produces zero MCP progress,
+    however long it runs. Pass the same instance as both `log_handler=` and
+    `websocket=` to GPTResearcher to cover both paths.
     """
 
     def __init__(self, ctx) -> None:
@@ -138,9 +158,36 @@ class ProgressLogHandler:
     async def on_agent_action(self, action: str, **kwargs: Any) -> None:
         await self._report(f"action:{action}")
 
+    async def send_json(self, data: Dict[str, Any]) -> None:
+        message = data.get("output") or data.get("content") or data.get("type") or "progress"
+        # Most payloads reaching here are short human-readable log lines,
+        # but a few (e.g. the image-planning step's JSON-dumped image
+        # list) can run to multiple KB -- cap so one progress notification
+        # can't balloon.
+        await self._report(str(message)[:200])
+
     async def _report(self, message: str) -> None:
         self._step += 1
-        await self._ctx.report_progress(progress=self._step, message=message)
+        try:
+            await self._ctx.report_progress(progress=self._step, message=message)
+        except Exception:
+            # Progress reporting is best-effort telemetry, not part of the
+            # research result. The log_handler path (agent.py's
+            # _log_event) already swallows handler errors so a broken
+            # handler can't take down conduct_research(); the
+            # websocket-shaped stream_output() path this also serves
+            # (gpt_researcher/actions/utils.py) awaits send_json()
+            # unguarded, so without this a transport hiccup here would
+            # propagate out of conduct_research() and discard whatever
+            # research had already completed.
+            #
+            # loguru does NOT support the standard-library exc_info=
+            # kwarg -- it's silently absorbed as an unused str.format()
+            # argument, producing a log line with no exception type, no
+            # message, and no traceback. logger.opt(exception=True) is
+            # loguru's actual mechanism for attaching the current
+            # exception.
+            logger.opt(exception=True).warning("Failed to report MCP progress")
 
 
 def create_research_prompt(topic: str, goal: str, report_format: str = "research_report") -> str:

--- a/utils.py
+++ b/utils.py
@@ -51,18 +51,23 @@ def get_researcher_by_id(researchers_dict: Dict, research_id: str) -> Tuple[bool
 def format_sources_for_response(sources: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
     """
     Format source information for API responses.
-    
+
     Args:
         sources: List of source dictionaries
-        
+
     Returns:
         Formatted source list for API responses
     """
+    # GPTResearcher.get_research_sources() populates each dict from
+    # gpt_researcher's scraper output (gpt_researcher/scraper/scraper.py),
+    # which keys the scraped text as "raw_content", not "content". Reading
+    # "content" here always missed, so content_length was 0 for every source
+    # regardless of how much text was actually scraped.
     return [
         {
             "title": source.get("title", "Unknown"),
             "url": source.get("url", ""),
-            "content_length": len(source.get("content", ""))
+            "content_length": len(source.get("raw_content", "") or "")
         }
         for source in sources
     ]


### PR DESCRIPTION
## Summary

Three related fixes to `deep_research`/`quick_search`, found while running this server against long, real research queries in production:

1. **`content_length` always 0 for every source.** `format_sources_for_response()` read `source.get("content", "")`, but `GPTResearcher.get_research_sources()` returns dicts keyed `"raw_content"` (see `gpt_researcher/scraper/scraper.py`). The `"content"` key never existed, so every source reported `content_length: 0` regardless of how much text was actually scraped -- indistinguishable from a source that genuinely failed.

2. **No progress signal during long calls.** `GPTResearcher` already accepts a `log_handler` and fires a dozen-plus internal step events via `_log_event()` throughout `conduct_research()`, but neither `deep_research` nor `quick_search` ever wired one up. A `deep_research` call against a broad query can legitimately run past a calling MCP client's idle timeout (Claude Code's default is 300s) with zero signal that work is ongoing -- the client can't distinguish "still working" from "hung," and may abort, permanently stranding the SSE session (a separate issue, tracked upstream in the MCP SDK). Added `ProgressLogHandler`, constructed with the tool call's `Context`, forwarding each step to an MCP progress notification.

3. **No synthesized report from `deep_research`.** Previously, getting an actual written report required knowing to call the separate `write_report` tool with the `research_id` `deep_research` returned -- easy to miss, and leaves most callers with a pile of source excerpts to read themselves. `deep_research` now also calls `write_report()` and includes it as `"report"` by default. Pass `synthesize_report=False` to keep the old gather-only behavior (no extra LLM call; `write_report` can still be called separately).

## Test plan

- Added `tests/test_deep_research_fixes.py`: drives both tools through an in-memory `fastmcp.Client` with a patched `GPTResearcher`, asserting progress events fire for both tools, `report` is present by default and omittable via `synthesize_report=False`, and `content_length` reflects actual scraped content (including the case where `raw_content` is absent, which must not crash).
- Ran the existing manual `tests/test_mcp_server.py` locally against a live server -- unaffected by these changes (same tool names/response shape, `report` and `synthesize_report` are additive).

Happy to split into separate PRs if that's easier to review -- these three were found and fixed together against the same production workload, but they're independent changes.