### PR TITLE
fix: build on Python 3.12 and skip the broken gpt-researcher 0.16.0 wheel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11-slim
+FROM python:3.12-slim
 
 WORKDIR /app
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # GPT Researcher dependencies
-gpt-researcher>=0.14.0
+gpt-researcher>=0.14.0,!=0.16.0
 python-dotenv
 
 # MCP dependencies


### PR DESCRIPTION
## What

- Base image `python:3.11-slim` -> `python:3.12-slim`.
- `requirements.txt`: `gpt-researcher>=0.14.0,!=0.16.0`.

## Why

`gpt-researcher` 0.16.0 on PyPI requires Python >= 3.12 and fails at import time: `gpt_researcher/actions/query_processing.py` uses `Any` and `List` without importing them (`NameError: name 'Any' is not defined`). The repository fixed this on 2026-08-23 (`fix: restore importability and multi-agent graph construction`) but no corrected wheel has been published yet.

Today the 3.11 base image keeps pip on 0.15.1 by accident; anyone building on 3.12 gets the broken wheel and a server that cannot start. Moving to 3.12 lets the image pick up current releases, and the explicit exclusion keeps it working until a fixed wheel ships. Verified: the 3.12 image builds and serves `tools/list` and `quick_search` with 0.15.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
